### PR TITLE
Feature/code refactor part3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -468,11 +468,11 @@
         },
         "openai": {
             "hashes": [
-                "sha256:1f07ed06f1cfc6c25126107193726fe4cf476edcc4e1485cd9eb708f068f2606",
-                "sha256:63ca9f6ac619daef8c1ddec6d987fe6aa1c87a9bfdce31ff253204d077222375"
+                "sha256:788fb7fa85bf7caac6c1ed7eea5984254a1bdaf09ef485acf0e5718c8b2dc25a",
+                "sha256:bca95fd4c3054ef38924def096396122130454442ec52005915ecf8269626b1d"
             ],
             "index": "pypi",
-            "version": "==0.27.6"
+            "version": "==0.27.7"
         },
         "packaging": {
             "hashes": [
@@ -516,11 +516,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294",
-                "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"
+                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
             "index": "pypi",
-            "version": "==2.30.0"
+            "version": "==2.31.0"
         },
         "tomli": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Converts [donjon](https://donjon.bin.sh) random dungeons into nice homebrewery v
 * Adds any monster stat blocks that exist in the SRD to the document and lists the ones it had to skip (5e only)
 * Collects all the monsters and magical items into easy to use reference tables with sourcebook page number (5e, 4e limited)
 * Provides total XP and a breakdown of combat encounter difficulty types (5e only, 4e limited)
-* Tries to add page breaks to reduce amount of manual editing required
+* Adds page breaks throughout the document regardless of ruleset to reduce amount of manual editing required
 * Captures all the settings used to generate this dungeon on donjon.bin.sh for prosperity
 * Ability to customise certain parts of room locations so important details aren't missed
 

--- a/dth/content/location.py
+++ b/dth/content/location.py
@@ -5,7 +5,7 @@ from dth.utilities.locations import sum_up_treasure, add_magical_items_to_list, 
 NEWLINE = '\n'
 
 
-def create_single_location(room, settings, magic_items, monster_list, combat_list, xp_list):
+def create_donjon_single_location(room, settings, magic_items, monster_list, combat_list, xp_list):
     """ 
         Create dict of single location
 
@@ -32,7 +32,7 @@ def create_single_location(room, settings, magic_items, monster_list, combat_lis
             if "trap" in room["contents"]["detail"]:
                 location["is_trap"] = True
                 for detail in room["contents"]["detail"]["trap"]:
-                    trap_detail.append(detail.replace(NEWLINE, ""))
+                    trap_detail.append(f"{detail.replace(NEWLINE, '')}.")
                 location["trap"] = trap_detail
 
             # hidden treasure
@@ -40,7 +40,7 @@ def create_single_location(room, settings, magic_items, monster_list, combat_lis
                 for detail in room["contents"]["detail"]["hidden_treasure"]:
                     if detail == "--":
                         continue
-                    hidden_treasure.append(detail.replace(NEWLINE, " "))
+                    hidden_treasure.append(f"{detail.replace(NEWLINE, ' ')}.")
                 location["hidden_treasure"] = hidden_treasure
                 
                 # add to magic items list for the summary page

--- a/dth/content/statblock.py
+++ b/dth/content/statblock.py
@@ -4,7 +4,8 @@ from utilities.statblocks import (
                             request_monster_statblock,
                             get_ability_modifier,
                             extract_proficiencies_from_api_response,
-                            convert_low_cr_to_fraction
+                            convert_low_cr_to_fraction,
+                            format_armour_type
                             )
 
 
@@ -27,11 +28,11 @@ def create_5e_statblock(monster, skipped_monsters):
     monster_statblock["alignment"] = response["alignment"].title()
     monster_statblock["ac"] = response["armor_class"][0]["value"]
 
-    # TODO: change to include shield in brackets after armor type
+    # work out correct armour type(s) to show
     if "type" in response["armor_class"][0]:
-        monster_statblock["armour_type"] = response["armor_class"][0]["type"]
+        monster_statblock["armour_type"] = format_armour_type(response["armor_class"])
     else:
-        monster_statblock["armour_type"] = response["armor_class"][0][0]["armor"][0]["name"]
+        monster_statblock["armor_type"] = ""
         
     monster_statblock['hp'] = response["hit_points"]
     monster_statblock['hp_formula'] = response["hit_points_roll"]

--- a/dth/content/statblock.py
+++ b/dth/content/statblock.py
@@ -1,0 +1,136 @@
+""" Dict to hold all settings used to generate a 5e stat block """
+
+from utilities.statblocks import (
+                            request_monster_statblock,
+                            get_ability_modifier,
+                            extract_proficiencies_from_api_response,
+                            convert_low_cr_to_fraction
+                            )
+
+
+def create_5e_statblock(monster, skipped_monsters):
+    """ create dict for statblock and add not founds to skipped list """
+    monster_statblock = {}
+    stat_block_size = 0
+
+    # api call to dnd5eapi
+    response = request_monster_statblock(monster)
+
+    # check for any monsters listed as in monster manual but not found in api
+    if response == "not found":
+        skipped_monsters.append(monster.replace("-", " ").title())
+        return {}, skipped_monsters
+
+    monster_statblock["name"] = response["name"].capitalize()
+    monster_statblock["size"] = response["size"].capitalize()
+    monster_statblock["type"] = response["type"].capitalize()
+    monster_statblock["alignment"] = response["alignment"].title()
+    monster_statblock["ac"] = response["armor_class"][0]["value"]
+
+    # TODO: change to include shield in brackets after armor type
+    if "type" in response["armor_class"][0]:
+        monster_statblock["armour_type"] = response["armor_class"][0]["type"]
+    else:
+        monster_statblock["armour_type"] = response["armor_class"][0][0]["armor"][0]["name"]
+        
+    monster_statblock['hp'] = response["hit_points"]
+    monster_statblock['hp_formula'] = response["hit_points_roll"]
+
+    # handle additional movement types
+    if len(response['speed']) > 1:
+        movement_types = []
+        for key, value in response['speed'].items():
+            movement_types.append(f"{key.capitalize()} {value}")
+        monster_statblock["speed"] = ', '.join(movement_types).replace('Walk ', '')
+    else:
+        monster_statblock["speed"] = response['speed']['walk']
+
+    # attributes and modifiers
+    monster_statblock["str"] = response["strength"]
+    monster_statblock["str_mod"] = get_ability_modifier(monster_statblock["str"])
+    monster_statblock["dex"] = response["dexterity"]
+    monster_statblock["dex_mod"] = get_ability_modifier(monster_statblock["dex"])
+    monster_statblock["con"] = response["constitution"]
+    monster_statblock["con_mod"] = get_ability_modifier(monster_statblock["con"])
+    monster_statblock["int"] = response["intelligence"]
+    monster_statblock["int_mod"] = get_ability_modifier(monster_statblock["int"])
+    monster_statblock["wis"] = response["wisdom"]
+    monster_statblock["wis_mod"] = get_ability_modifier(monster_statblock["wis"])
+    monster_statblock["cha"] = response["charisma"]
+    monster_statblock["cha_mod"] = get_ability_modifier(monster_statblock["cha"])
+
+    # extract saving throws and skill check modifiers
+    saving_throws, skill_checks = extract_proficiencies_from_api_response(response)
+    if saving_throws:
+        throws = []
+        for key, value in saving_throws:
+            throws.append(f"{key.capitalize()} +{value}")
+        monster_statblock["saving_throws"] = ', '.join(throws)
+
+    if skill_checks:
+        skills = []
+        for key, value in skill_checks:
+            skills.append(f"{key.capitalize()} +{value}")
+        monster_statblock["skill_checks"] = ', '.join(skills)
+
+    #resistances and immunities
+    if response["damage_vulnerabilities"]:
+        monster_statblock["damage_vulnerabilities"] = ', '.join(response["damage_vulnerabilities"])
+
+    if response["damage_resistances"]:
+        monster_statblock["damage_resistances"] = ', '.join(response["damage_resistances"])
+
+    if response["damage_immunities"]:
+        monster_statblock["damage_immunities"] = ', '.join(response["damage_immunities"])
+
+    if response["condition_immunities"]:
+        con_imm_list = []
+        for condition_immunity in response["condition_immunities"]:
+            con_imm_list.append(condition_immunity["index"])
+        monster_statblock["condition_immunities"] = ', '.join(con_imm_list)
+
+    # extract senses
+    monster_statblock["senses"] = str(response["senses"]).replace("{", "").replace("}", "").replace("'", "").replace(":", "").replace("_", " ")
+
+    # languages
+    if response["languages"]:
+        monster_statblock["languages"] = response["languages"]
+        stat_block_size += len(response["languages"])
+
+    # cr and xp
+    CR = convert_low_cr_to_fraction(response["challenge_rating"])
+    monster_statblock["CR"] = CR
+    monster_statblock["XP"] = response["xp"]
+
+    # traits and special abilities
+    if response["special_abilities"]:
+        special_abilities = {}
+        for ability in response["special_abilities"]:
+            special_abilities[ability["name"]] = ability["desc"]
+            stat_block_size += (len(ability["name"]) + len(ability["desc"]))
+        monster_statblock["special_abilities"] = special_abilities
+
+    # monster actions
+    if response["actions"]:
+        actions = {}
+        for action in response["actions"]:
+            actions[action["name"]] = action["desc"]
+            stat_block_size += (len(action["name"]) + len(action["desc"]))
+        monster_statblock["actions"] = actions
+
+    # set stat block size
+    if stat_block_size >= 700:
+        monster_statblock["markdown_size"] = "2"
+    else:
+        monster_statblock["markdown_size"] = "1"
+
+    # monster legendary actions
+    if response["legendary_actions"]:
+        legendary_actions = {}
+        for legendary_action in response["legendary_actions"]:
+            legendary_actions[legendary_action["name"]] = legendary_action["desc"]
+        monster_statblock["legendary_actions"] = legendary_actions
+        # set stat block size as 2 for legendary action monsters by default
+        monster_statblock["markdown_size"] = "2"
+
+    return monster_statblock, skipped_monsters

--- a/dth/utilities/statblocks.py
+++ b/dth/utilities/statblocks.py
@@ -1,5 +1,6 @@
 """Module providing statblock & dnd api helper functions"""
 import requests
+from dth.utilities.summary import dedupe_and_sort_list_via_dict
 
 
 def request_monster_statblock(monster_name):
@@ -48,3 +49,19 @@ def convert_low_cr_to_fraction(number):
         if number == 0.125:
             return "1/8"
     return f"{number}"
+
+
+def format_armour_type(armour):
+    """ format armour and include all types i.e. shield """
+    armour_list = []
+    if armour[0]["type"] == "armor":
+        if len(armour[0]["armor"]) > 1:
+            for type in armour[0]["armor"]:
+                armour_list.append(type["name"].lower())
+            return f"({', '.join(dedupe_and_sort_list_via_dict(armour_list))})"
+        else:
+            return f"({armour[0]['armor'][0]['name'].lower()})"
+    elif armour[0]["type"] == "natural":
+        return "(natural)"
+    else:
+        return ""

--- a/dth/utilities/summary.py
+++ b/dth/utilities/summary.py
@@ -2,7 +2,16 @@
 
 
 def calculate_total_and_shared_xp(xp_list, party_size):
+    """ calculate total and shared xp based on combat and party size"""
     total_xp = sum(int(i) for i in xp_list)
     shared_xp = round(sum(int(i) for i in xp_list)/int(party_size))
 
     return total_xp, shared_xp
+
+
+def dedupe_and_sort_list_via_dict(input_list):
+        """ dedupes and sorts list using dict """
+        output_list = list(dict.fromkeys(input_list))
+        output_list.sort()
+
+        return output_list

--- a/templates/default.css
+++ b/templates/default.css
@@ -1,3 +1,6 @@
+/* suppress detail at bottom of cover (front and back) */
+.page#p1:after { display:none; } 
+
 .treasure {
 	/* treasure custom style */
 }

--- a/templates/stylised.css
+++ b/templates/stylised.css
@@ -1,5 +1,8 @@
 /* source: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Border-image_generator */
 
+/* suppress detail at bottom of cover (front and back) */
+.page#p1:after { display:none; } 
+
 .treasure {
 	/* treasure custom style */
 }
@@ -13,6 +16,7 @@
 	border-image-repeat: round round;
 	border-image-source: url("https://mdn.github.io/css-examples/tools/border-image-generator/border-image-3.png");
 	border-style: solid;
+	margin-bottom: 5px;
 }
 
 .hidden-treasure {
@@ -24,4 +28,5 @@
 	border-image-repeat: round round;
 	border-image-source: url("https://mdn.github.io/css-examples/tools/border-image-generator/border-image-6.svg");
 	border-style: solid;
+	margin-bottom: 5px;
 }

--- a/tests/outputs/4e.txt
+++ b/tests/outputs/4e.txt
@@ -60,7 +60,7 @@ There are also roaming groups with specific goals, this will help you place them
 ### Room 1
 {{trap
 #### Trap!
-* Spinning Blades (Perception DC 12 to find, Thievery DC 17 to disable, Init +2, Close burst 1, Attack +11 vs. AC, Damage 1d10+4, 250 xp)
+* Spinning Blades (Perception DC 12 to find, Thievery DC 17 to disable, Init +2, Close burst 1, Attack +11 vs. AC, Damage 1d10+4, 250 xp).
 }}
 #### Exits
 | Direction | Description | To |
@@ -118,7 +118,7 @@ None
 ### Room 6
 {{trap
 #### Trap!
-* Spinning Blades (Perception DC 17 to find, Thievery DC 12 to disable, Init +2, Close burst 1, Attack +11 vs. AC, Damage 1d10+4, 250 xp)
+* Spinning Blades (Perception DC 17 to find, Thievery DC 12 to disable, Init +2, Close burst 1, Attack +11 vs. AC, Damage 1d10+4, 250 xp).
 }}
 {{descriptive
 A balcony hangs from the west wall, and a faded and torn tapestry hangs from the south wall.
@@ -128,15 +128,15 @@ This room is occupied by **4 x Poltergeist (og 150, 250 xp)**
 #### Treasure
 Small Rock Crystal (173 gp each); Stoneware Jar painted with Garden Imagery (350 gp); hoard total 523 gp
 }}
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
 | South | Archway  | n/a |
 | West | Locked Iron Door (Thievery DC 10 to unlock, Strength DC 30 to break, 60 hp)  | 101 |
 :
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 ### Room 7
 {{descriptive
 Fiery brazier (Strength DC 10 to knock over, deals ongoing 5 fire damage), The walls have been engraved with endless spirals.
@@ -192,7 +192,7 @@ A chute falls into the room from above, and the north and west walls have been e
 ### Room 11
 {{trap
 #### Trap!
-* 4 x Dart Blaster (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close blast 2, Attack +11 vs. AC, Damage 3d6+4, 63 xp)
+* 4 x Dart Blaster (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close blast 2, Attack +11 vs. AC, Damage 3d6+4, 63 xp).
 }}
 {{descriptive
 Clouds of smoke (provides concealment), Part of the ceiling has collapsed into the room.
@@ -202,6 +202,9 @@ This room is occupied by **7 x Shadow Speaker (mm3 39, 250 xp)**
 #### Treasure
 576 gp; 3 x Small Sardonyx (171 gp each); Bone Medallion set with Golden Yellow Topaz (270 gp); +2 Magic Tome (ap 151, 1800 gp), +2 Orb of Impenetrable Escape (av 94, 1800 gp), 10 x Arcane Ritual Scroll (Leomund's Secret Chest (phb 307, 360 gp)), 10 x Goodnight Tincture (av 28, 150 gp); hoard total 10059 gp
 }}
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
@@ -209,9 +212,6 @@ This room is occupied by **7 x Shadow Speaker (mm3 39, 250 xp)**
 | North | Wooden Portcullis (Strength DC 15 to open, 20 hp)  | 100 |
 | South | Archway  | n/a |
 :
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 ### Room 12
 {{descriptive
 Lightning generator (deals 1d10+4 lightning damage), A crater has been blasted into the floor in the south-east corner of the room.
@@ -241,7 +241,7 @@ Entropic altar (healing is only half as effective), A wooden ladder rests agains
 ### Room 14
 {{trap
 #### Trap!
-* 6 x Spinning Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp)
+* 6 x Spinning Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp).
 }}
 {{descriptive
 Arcane engine, Crude ballista (Strength DC 17 to arm, Dex attack vs. AC, deals 3d10+4 damage, single use).
@@ -276,18 +276,18 @@ Clouds of solid fog (provides concealment, difficult terrain), A simple fireplac
 | North | Trapped and Stuck Good Wooden Door (Strength DC 15 to break, 30 hp) (slides up, +2 to break DC)  ***Trap:*** Fire Blaster (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Close blast 1, Attack +9 vs. Reflex, Damage 3d6+4 fire, 63 xp) | n/a |
 | North | Trapped Wooden Portcullis (Strength DC 15 to open, 20 hp)  | 65 |
 :
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 ### Room 17
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 30 to find) Locked Good Wooden Chest (Thievery DC 15 to unlock, Strength DC 18 to break, 30 hp)
-* None
+* Hidden (Perception DC 30 to find) Locked Good Wooden Chest (Thievery DC 15 to unlock, Strength DC 18 to break, 30 hp).
+* None.
 }}
 {{descriptive
 A magical mirror on the north wall answers questions with lies and falsehoods, and a faded and torn tapestry hangs from the south wall.
 }}
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 This room is occupied by **4 x Adept of Orcus (mm3 95, 250 xp)**
 {{treasure
 #### Treasure
@@ -302,7 +302,7 @@ None
 ### Room 18
 {{trap
 #### Trap!
-* Bolter Turret (Perception DC 12 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp)
+* Bolter Turret (Perception DC 12 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp).
 }}
 {{descriptive
 Pool of acid (difficult terrain, deals 1d10+4 acid damage), Mysterious levers and mechanisms cover the walls.
@@ -321,7 +321,7 @@ This room is occupied by **6 x Chitine Marauder (mm3 32, 250 xp)**
 ### Room 19
 {{trap
 #### Trap!
-* Telekinetic Blaster (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 10 squares, Attack +9 vs. Fortitude, the target is pushed 2 squares, 250 xp)
+* Telekinetic Blaster (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 10 squares, Attack +9 vs. Fortitude, the target is pushed 2 squares, 250 xp).
 }}
 {{descriptive
 Numerous pillars line the south and east walls, and several headless statues are scattered throughout the room.
@@ -340,7 +340,7 @@ This room is occupied by **2 x Iron Cobra (mm 157, 250 xp)**
 ### Room 20
 {{trap
 #### Trap!
-* Arcane Bolter (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 20 squares, Attack +11 vs. AC, Damage 1d10+4 force, 250 xp)
+* Arcane Bolter (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 20 squares, Attack +11 vs. AC, Damage 1d10+4 force, 250 xp).
 }}
 {{descriptive
 A sloped pit lined with iron spikes lies in the south-east corner of the room, and spirals of yellow stones cover the floor.
@@ -359,9 +359,9 @@ A sloped pit lined with iron spikes lies in the south-east corner of the room, a
 ### Room 21
 {{hidden-treasure
 #### Hidden Treasure!
-* Trapped and Locked Strong Wooden Chest (Thievery DC 20 to unlock, Strength DC 20 to break, 40 hp)
-* Teleporter Crystal (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Will, the target is teleported 17 squares, 63 xp)
-* None
+* Trapped and Locked Strong Wooden Chest (Thievery DC 20 to unlock, Strength DC 20 to break, 40 hp).
+* Teleporter Crystal (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Will, the target is teleported 17 squares, 63 xp).
+* None.
 }}
 {{descriptive
 Scaffolding (Acrobatics or Athletics DC 10 to climb), Barred partition walls (provides cover, Strength DC 20 to break).
@@ -407,7 +407,7 @@ This room is occupied by **6 x Wyrmwarped Scaleshaper (dr1 225, 250 xp)**
 ### Room 24
 {{trap
 #### Trap!
-* 4 x Frostcyst Burster (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Close burst 2, Attack +9 vs. Fortitude, Damage 3d6+4 cold      and the target is weakened until the end of its next turn, 63 xp)
+* 4 x Frostcyst Burster (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Close burst 2, Attack +9 vs. Fortitude, Damage 3d6+4 cold      and the target is weakened until the end of its next turn, 63 xp).
 }}
 This room is occupied by **5 x Chitine Web Crafter (mm3 33, 250 xp)**
 {{treasure
@@ -460,7 +460,7 @@ This room is occupied by **4 x Chillborn Zombie (mm 275, 250 xp)**
 ### Room 28
 {{trap
 #### Trap!
-* 5 x Spinning Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp)
+* 5 x Spinning Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp).
 }}
 #### Exits
 | Direction | Description | To |
@@ -474,7 +474,7 @@ This room is occupied by **4 x Chillborn Zombie (mm 275, 250 xp)**
 ### Room 29
 {{trap
 #### Trap!
-* 7 x Spinning Floortile (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp)
+* 7 x Spinning Floortile (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp).
 }}
 {{descriptive
 Psychic resonance (+2 to attacks vs. Will), Several wax blobs are scattered throughout the room.
@@ -517,8 +517,8 @@ This room is occupied by **5 x Iron Cobra (mm 157, 250 xp)**
 ### Room 32
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 30 to find) Unlocked Strong Wooden Chest (Strength DC 15 to break, 40 hp)
-* 3600 sp; 3 x Small Chrysoprase (176 gp each), 2 x Uncut Onyx (183 gp each); Linen Mantle trimmed with Rabbit Fur (310 gp); +2 Amulet of Protection (phb 249, 1800 gp), +2 Sacrificial Weapon (av 77, 1800 gp) Spiked Gauntlet (av 9), Divine Ritual Scroll (Thief's Lament (dp 158, 360 gp)), 10 x Martial Practice (Precise Forgery (mp2 151, 80 gp)), 7 x Trackless Ashes (mme 101, 75 gp); hoard total 6849 gp
+* Hidden (Perception DC 30 to find) Unlocked Strong Wooden Chest (Strength DC 15 to break, 40 hp).
+* 3600 sp; 3 x Small Chrysoprase (176 gp each), 2 x Uncut Onyx (183 gp each); Linen Mantle trimmed with Rabbit Fur (310 gp); +2 Amulet of Protection (phb 249, 1800 gp), +2 Sacrificial Weapon (av 77, 1800 gp) Spiked Gauntlet (av 9), Divine Ritual Scroll (Thief's Lament (dp 158, 360 gp)), 10 x Martial Practice (Precise Forgery (mp2 151, 80 gp)), 7 x Trackless Ashes (mme 101, 75 gp); hoard total 6849 gp.
 }}
 {{footnote LOCATIONS}}
 \page
@@ -543,7 +543,7 @@ Lightning generator (deals 1d10+4 lightning damage), Lightning mist (moving more
 ### Room 34
 {{trap
 #### Trap!
-* 4 x Concealed Pit (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d8+4 falling, 63 xp)
+* 4 x Concealed Pit (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d8+4 falling, 63 xp).
 }}
 {{descriptive
 Lightning generator (deals 1d10+4 lightning damage), A chute falls into the room from above.
@@ -574,7 +574,7 @@ Pool of acid (difficult terrain, deals 1d10+4 acid damage), Someone has scrawled
 ### Room 36
 {{trap
 #### Trap!
-* 5 x Dart Blaster (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Close blast 1, Attack +11 vs. AC, Damage 3d6+4, 63 xp)
+* 5 x Dart Blaster (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Close blast 1, Attack +11 vs. AC, Damage 3d6+4, 63 xp).
 }}
 {{descriptive
 A fountain decorated with tormented faces sits in the north side of the room, and the sound of dripping water fills the room.
@@ -608,7 +608,7 @@ Set of Crystal Dice (430 gp); +2 Magic Tome (ap 151, 1800 gp); hoard total 2230 
 ### Room 38
 {{trap
 #### Trap!
-* 6 x Electrified Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Fortitude, Damage 3d8+4 lightning, 63 xp)
+* 6 x Electrified Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Fortitude, Damage 3d8+4 lightning, 63 xp).
 }}
 #### Exits
 | Direction | Description | To |
@@ -666,7 +666,7 @@ This room is occupied by **3 x Wyrmwarped Scaleshaper (dr1 225, 250 xp) and 3 x 
 ### Room 43
 {{trap
 #### Trap!
-* 3 x Spinning Floortile (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp)
+* 3 x Spinning Floortile (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp).
 }}
 {{footnote LOCATIONS}}
 \page
@@ -712,7 +712,7 @@ This room is occupied by **8 x Dragonkin Kobold Defender (dr1 226, 250 xp)**
 ### Room 46
 {{trap
 #### Trap!
-* 2 x Spinning Floortile (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp)
+* 2 x Spinning Floortile (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp).
 }}
 {{descriptive
 Lightning mist (moving more than 2 squares per round deals 1d6+4 lightning damage), Someone has scrawled "Mind the gap" on the east wall.
@@ -732,7 +732,7 @@ This room is occupied by **6 x Ghast (mm3 95, 250 xp)**
 ### Room 47
 {{trap
 #### Trap!
-* 3 x Chain Flail (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close burst 4, Attack +11 vs. AC, Damage 3d6+4 and the target is knocked prone, 63 xp)
+* 3 x Chain Flail (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close burst 4, Attack +11 vs. AC, Damage 3d6+4 and the target is knocked prone, 63 xp).
 }}
 {{footnote LOCATIONS}}
 \page
@@ -776,7 +776,7 @@ This room is occupied by **5 x Chillborn Zombie (mm 275, 250 xp)**
 ### Room 50
 {{trap
 #### Trap!
-* 3 x Falling Block (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp)
+* 3 x Falling Block (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp).
 }}
 {{descriptive
 Shadowmere floor (creatures knocked prone are trapped in a mirror world), Barred partition walls (provides cover, Strength DC 20 to break).
@@ -798,7 +798,7 @@ This room is occupied by **3 x Deathdog (og 158, 500 xp)**
 ### Room 51
 {{trap
 #### Trap!
-* 2 x Chain Flail (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Close burst 3, Attack +11 vs. AC, Damage 3d6+4 and the target is knocked prone, 63 xp)
+* 2 x Chain Flail (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Close burst 3, Attack +11 vs. AC, Damage 3d6+4 and the target is knocked prone, 63 xp).
 }}
 {{descriptive
 A chute falls into the room from above, and a faded and torn tapestry hangs from the south wall.
@@ -839,7 +839,7 @@ Sloped floor (add 1 square to any movement towards the east side of the room), S
 ### Room 54
 {{trap
 #### Trap!
-* 5 x Frostcyst Burster (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close burst 1, Attack +9 vs. Fortitude, Damage 3d6+4 cold      and the target is weakened until the end of its next turn, 63 xp)
+* 5 x Frostcyst Burster (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close burst 1, Attack +9 vs. Fortitude, Damage 3d6+4 cold      and the target is weakened until the end of its next turn, 63 xp).
 }}
 {{descriptive
 Someone has scrawled "The cleric will betray you" on the east wall, and the floor is covered with mould.
@@ -863,7 +863,7 @@ This room is occupied by **6 x Duergar Shock Trooper (mm2 93, 250 xp)**
 ### Room 55
 {{trap
 #### Trap!
-* Arcane Bolter (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 20 squares, Attack +11 vs. AC, Damage 1d10+4 force, 250 xp)
+* Arcane Bolter (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 20 squares, Attack +11 vs. AC, Damage 1d10+4 force, 250 xp).
 }}
 #### Exits
 | Direction | Description | To |
@@ -873,12 +873,12 @@ This room is occupied by **6 x Duergar Shock Trooper (mm2 93, 250 xp)**
 ### Room 56
 {{trap
 #### Trap!
-* Pendulum Scythes (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target all creatures in a row of squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp)
+* Pendulum Scythes (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target all creatures in a row of squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp).
 }}
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 20 to find) Locked Good Wooden Chest (Thievery DC 15 to unlock, Strength DC 18 to break, 30 hp)
-* 2 x Carved Freshwater Pearl (185 gp each), 3 x Uncut Bloodstone (186 gp each); +2 Summoned Armor (av 53, 1800 gp) Leather Armor (phb 214); hoard total 2728 gp
+* Hidden (Perception DC 20 to find) Locked Good Wooden Chest (Thievery DC 15 to unlock, Strength DC 18 to break, 30 hp).
+* 2 x Carved Freshwater Pearl (185 gp each), 3 x Uncut Bloodstone (186 gp each); +2 Summoned Armor (av 53, 1800 gp) Leather Armor (phb 214); hoard total 2728 gp.
 }}
 #### Exits
 | Direction | Description | To |
@@ -889,7 +889,7 @@ This room is occupied by **6 x Duergar Shock Trooper (mm2 93, 250 xp)**
 ### Room 57
 {{trap
 #### Trap!
-* 5 x Falling Block (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp)
+* 5 x Falling Block (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp).
 }}
 {{descriptive
 Ladder to suspended walkway, A rusted chain shirt lies in the north-west corner of the room.
@@ -907,7 +907,7 @@ This room is occupied by **7 x Chillborn Zombie (mm 275, 250 xp)**
 ### Room 58
 {{trap
 #### Trap!
-* Necrotic Blaster (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 10 squares, Attack +9 vs. Fortitude, Damage 1d10+4 necrotic, 250 xp)
+* Necrotic Blaster (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Target 1 creature within 10 squares, Attack +9 vs. Fortitude, Damage 1d10+4 necrotic, 250 xp).
 }}
 {{descriptive
 Numerous pillars line the west wall, and several wax blobs are scattered throughout the room.
@@ -930,8 +930,8 @@ This room is occupied by **3 x Spined Devil (mm 66, 250 xp) and 5 x Legion Devil
 ### Room 59
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 15 to find) Locked Iron Chest (Thievery DC 15 to unlock, Strength DC 30 to break, 60 hp)
-* 10080 sp; 2 x Small Rock Crystal (172 gp each), 2 x Uncut Carnelian (172 gp each); Small Woolen Tapestry (430 gp); +2 Dynamic Weapon (av 68, 1800 gp) Long Spear (phb 218), +2 Summoned Armor (av 53, 1800 gp) Plate Armor (phb 214), 9 x Augmenting Whetstone (av 190, 75 gp), 7 x Goodnight Tincture (av 28, 150 gp), 6 x Trackless Ashes (mme 101, 75 gp); hoard total 7901 gp
+* Hidden (Perception DC 15 to find) Locked Iron Chest (Thievery DC 15 to unlock, Strength DC 30 to break, 60 hp).
+* 10080 sp; 2 x Small Rock Crystal (172 gp each), 2 x Uncut Carnelian (172 gp each); Small Woolen Tapestry (430 gp); +2 Dynamic Weapon (av 68, 1800 gp) Long Spear (phb 218), +2 Summoned Armor (av 53, 1800 gp) Plate Armor (phb 214), 9 x Augmenting Whetstone (av 190, 75 gp), 7 x Goodnight Tincture (av 28, 150 gp), 6 x Trackless Ashes (mme 101, 75 gp); hoard total 7901 gp.
 }}
 {{descriptive
 Someone has scrawled "I'd rather be at the Jester and Flagon" in dwarvish runes on the east wall, and several barrel staves are scattered throughout the room.
@@ -970,7 +970,7 @@ This room is occupied by **4 x Chitine Marauder (mm3 32, 250 xp)**
 ### Room 62
 {{trap
 #### Trap!
-* Petrification Ray (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 10 squares, Attack +9 vs. Fortitude, the target is slowed (save ends), First Failed Save the target is immobilized (save ends), Second Failed Save the target is petrified (no save), 250 xp)
+* Petrification Ray (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 10 squares, Attack +9 vs. Fortitude, the target is slowed (save ends), First Failed Save the target is immobilized (save ends), Second Failed Save the target is petrified (no save), 250 xp).
 }}
 {{descriptive
 Fire pit (deals 1d10+4 fire damage), A rattling noise can be faintly heard near the east wall.
@@ -1012,7 +1012,7 @@ None
 ### Room 65
 {{trap
 #### Trap!
-* 4 x Arrow Trap (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 3d8+4, 63 xp)
+* 4 x Arrow Trap (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 3d8+4, 63 xp).
 }}
 {{descriptive
 Pool of water (difficult terrain), A tile labyrinth covers the floor.
@@ -1058,7 +1058,7 @@ Someone has scrawled "You cannot kill it with magic" in draconic script on the n
 ### Room 68
 {{trap
 #### Trap!
-* Firebomb Turret (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Area burst 2 within 10 squares, Attack +9 vs. Reflex, Damage 1d6+4 fire and ongoing 5 fire (save ends), 250 xp)
+* Firebomb Turret (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Area burst 2 within 10 squares, Attack +9 vs. Reflex, Damage 1d6+4 fire and ongoing 5 fire (save ends), 250 xp).
 }}
 This room is occupied by **1 x Kruthik Hive Lord (mm 170, 1250 xp) and 6 x Kruthik Adult (mm 170, 175 xp)**
 {{treasure
@@ -1122,7 +1122,7 @@ None
 ### Room 72
 {{trap
 #### Trap!
-* Bolter Turret (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp)
+* Bolter Turret (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp).
 }}
 {{descriptive
 A magical statue in the north side of the room answers questions with insults, and a group of draconic faces have been carved into the north wall.
@@ -1138,7 +1138,7 @@ A magical statue in the north side of the room answers questions with insults, a
 ### Room 73
 {{trap
 #### Trap!
-* 8 x Concealed Pit (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d8+4 falling, 63 xp)
+* 8 x Concealed Pit (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d8+4 falling, 63 xp).
 }}
 This room is occupied by **6 x Shadow Hound (mm 160, 250 xp)**
 {{treasure
@@ -1165,10 +1165,10 @@ This room is occupied by **1 x Kruthik Hive Lord (mm 170, 1250 xp) and 6 x Kruth
 | East | Trapped Wooden Portcullis (Strength DC 15 to open, 20 hp)  | n/a |
 | West | Trapped and Stuck Iron Door (Strength DC 28 to break, 60 hp) (slides up, +2 to break DC)  ***Trap:*** Acidic Burster (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close burst 4, Attack +9 vs. Reflex, Damage 3d6+4 acid, 63 xp) | n/a |
 :
-### Room 75
 {{footnote LOCATIONS}}
 \page
 {{pageNumber,auto}}
+### Room 75
 {{descriptive
 Someone has scrawled "Explosive runes" in draconic script on the north wall, and the north and east walls are covered with bloodstains.
 }}
@@ -1186,7 +1186,7 @@ This room is occupied by **5 x Dread Archer (mm3 75, 250 xp)**
 ### Room 76
 {{trap
 #### Trap!
-* Hail of Needles (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Close burst 1, Attack +11 vs. AC, Damage 1d6+4, 250 xp)
+* Hail of Needles (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Close burst 1, Attack +11 vs. AC, Damage 1d6+4, 250 xp).
 }}
 {{descriptive
 Zone of reversed gravity, Fiery brazier (Strength DC 10 to knock over, deals ongoing 5 fire damage).
@@ -1227,8 +1227,8 @@ Sloped floor (add 1 square to any movement towards the east side of the room), P
 ### Room 79
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 15 to find) Locked Good Wooden Chest (Thievery DC 30 to unlock, Strength DC 18 to break, 30 hp)
-* 64 gp, 64 sp; Fine Steel Ring engraved with Arcane Runes (310 gp); +2 Grasping Weapon (av 70, 1800 gp) Long Spear (phb 218), 5 x Fire Beetle Potion (av 187, 75 gp), Sigil of Companionship (av 123, 1800 gp); hoard total 4355 gp 4 sp
+* Hidden (Perception DC 15 to find) Locked Good Wooden Chest (Thievery DC 30 to unlock, Strength DC 18 to break, 30 hp).
+* 64 gp, 64 sp; Fine Steel Ring engraved with Arcane Runes (310 gp); +2 Grasping Weapon (av 70, 1800 gp) Long Spear (phb 218), 5 x Fire Beetle Potion (av 187, 75 gp), Sigil of Companionship (av 123, 1800 gp); hoard total 4355 gp 4 sp.
 }}
 This room is occupied by **7 x Hobbler Kobold Savant (dr1 224, 250 xp)**
 {{treasure
@@ -1350,7 +1350,7 @@ This room is occupied by **5 x Spined Devil (mm 66, 250 xp)**
 ### Room 90
 {{trap
 #### Trap!
-* 3 x Spinning Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp)
+* 3 x Spinning Floortile (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp).
 }}
 #### Exits
 | Direction | Description | To |
@@ -1363,8 +1363,8 @@ This room is occupied by **5 x Spined Devil (mm 66, 250 xp)**
 ### Room 91
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 15 to find) Locked Good Wooden Chest (Thievery DC 20 to unlock, Strength DC 18 to break, 30 hp)
-* 3 x Crown Banded Agate (177 gp each); Fine Steel Shield Brooch engraved with Arcane Runes (340 gp), Portrait (of a male goliath) in a Wooden Frame inlaid with Copper (410 gp); +2 Orb of Mental Domination (av 95, 1800 gp); hoard total 3081 gp
+* Hidden (Perception DC 15 to find) Locked Good Wooden Chest (Thievery DC 20 to unlock, Strength DC 18 to break, 30 hp).
+* 3 x Crown Banded Agate (177 gp each); Fine Steel Shield Brooch engraved with Arcane Runes (340 gp), Portrait (of a male goliath) in a Wooden Frame inlaid with Copper (410 gp); +2 Orb of Mental Domination (av 95, 1800 gp); hoard total 3081 gp.
 }}
 #### Exits
 | Direction | Description | To |
@@ -1398,7 +1398,7 @@ Psychic resonance (+2 to attacks vs. Will), A charred club lies in the north sid
 ### Room 94
 {{trap
 #### Trap!
-* 4 x Arrow Trap (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 3d8+4, 63 xp)
+* 4 x Arrow Trap (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 3d8+4, 63 xp).
 }}
 {{descriptive
 Several square holes are cut into the north and south walls, and the south and east walls have been engraved with glowing runes.
@@ -1412,7 +1412,7 @@ Several square holes are cut into the north and south walls, and the south and e
 ### Room 95
 {{trap
 #### Trap!
-* 6 x Falling Block (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp)
+* 6 x Falling Block (Perception DC 17 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp).
 }}
 #### Exits
 | Direction | Description | To |
@@ -1423,7 +1423,7 @@ Several square holes are cut into the north and south walls, and the south and e
 ### Room 96
 {{trap
 #### Trap!
-* Pendulum Scythes (Perception DC 17 to find, Thievery DC 12 to disable, Init +2, Target all creatures in a row of squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp)
+* Pendulum Scythes (Perception DC 17 to find, Thievery DC 12 to disable, Init +2, Target all creatures in a row of squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp).
 }}
 This room is occupied by **6 x Duergar Shock Trooper (mm2 93, 250 xp)**
 {{footnote LOCATIONS}}
@@ -1455,12 +1455,12 @@ This room is occupied by **3 x Wyrmwarped Scaleshaper (dr1 225, 250 xp) and 4 x 
 ### Room 98
 {{trap
 #### Trap!
-* 4 x Rune of Insanity (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close burst 9, Attack +9 vs. Will, Damage 3d6+4 psychic, 63 xp)
+* 4 x Rune of Insanity (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Close burst 9, Attack +9 vs. Will, Damage 3d6+4 psychic, 63 xp).
 }}
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 20 to find) Locked Good Wooden Chest (Thievery DC 20 to unlock, Strength DC 18 to break, 30 hp)
-* 3 x Crown Azurite (181 gp each), 3 x Crown Moss Agate (187 gp each), Small Rose Quartz (171 gp each), 2 x Uncut Jasper (187 gp each); +2 Distance Weapon (av 68, 1800 gp) Handaxe (phb 218), +2 Mercurial Rod (av 99, 1800 gp); hoard total 5249 gp
+* Hidden (Perception DC 20 to find) Locked Good Wooden Chest (Thievery DC 20 to unlock, Strength DC 18 to break, 30 hp).
+* 3 x Crown Azurite (181 gp each), 3 x Crown Moss Agate (187 gp each), Small Rose Quartz (171 gp each), 2 x Uncut Jasper (187 gp each); +2 Distance Weapon (av 68, 1800 gp) Handaxe (phb 218), +2 Mercurial Rod (av 99, 1800 gp); hoard total 5249 gp.
 }}
 {{descriptive
 Numerous pillars line the north wall, and the ceiling is covered with cobwebs.
@@ -1480,7 +1480,7 @@ This room is occupied by **5 x Rust Monster (mm2 178, 250 xp)**
 ### Room 99
 {{trap
 #### Trap!
-* Bolter Turret (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp)
+* Bolter Turret (Perception DC 12 to find, Thievery DC 12 to disable, Init +2, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 1d10+4, 250 xp).
 }}
 {{descriptive
 Primordial altar (lightning atacks deal 1d6 extra damage), Lit candles are scattered across the floor.
@@ -1499,7 +1499,7 @@ Primordial altar (lightning atacks deal 1d6 extra damage), Lit candles are scatt
 ### Room 100
 {{trap
 #### Trap!
-* 4 x Falling Block (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp)
+* 4 x Falling Block (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, Damage 3d10+4, 63 xp).
 }}
 {{descriptive
 Oil slicks (add 1 square to forced movement), A pile of rotting wood lies in the east side of the room.
@@ -1529,7 +1529,7 @@ This room is occupied by **5 x Poltergeist (og 150, 250 xp)**
 ### Room 102
 {{trap
 #### Trap!
-* Fireball Turret (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Area burst 1 within 10 squares, Attack +9 vs. Reflex, Damage 1d6+4 fire, 250 xp)
+* Fireball Turret (Perception DC 17 to find, Thievery DC 17 to disable, Init +2, Area burst 1 within 10 squares, Attack +9 vs. Reflex, Damage 1d6+4 fire, 250 xp).
 }}
 {{descriptive
 Explosive fumes (explosion deals 3d10+4 fire damage), Linked teleporter circles.
@@ -1596,7 +1596,7 @@ Intermittent obstructions (provides cover), Vortex of necrotic energy (deals 1d1
 ### Room 107
 {{trap
 #### Trap!
-* 7 x Swinging Block (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Target all creatures in a row of squares, Attack +9 vs. Reflex, Damage 3d8+4, 63 xp)
+* 7 x Swinging Block (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Target all creatures in a row of squares, Attack +9 vs. Reflex, Damage 3d8+4, 63 xp).
 }}
 {{descriptive
 Stone barricades (provides cover, Strength DC 30 to break), A large kiln and coal bin sit in the west side of the room.
@@ -1610,8 +1610,8 @@ Stone barricades (provides cover, Strength DC 30 to break), A large kiln and coa
 ### Room 108
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 15 to find) Locked Simple Wooden Chest (Thievery DC 15 to unlock, Strength DC 15 to break, 20 hp)
-* Bone Scepter set with a Rosette of Carnelian (320 gp); +2 Imposter's Armor (av 46, 1800 gp) Drakescale Armor (av 7), +2 Magic Totem (phb2 208, 1800 gp), Arcane Ritual Book (Leomund's Secret Chest (phb 307, 360 gp), Thief's Lament (dp 158, 360 gp)) (total 720 gp), Smokestick (av 30, 150 gp); hoard total 4790 gp
+* Hidden (Perception DC 15 to find) Locked Simple Wooden Chest (Thievery DC 15 to unlock, Strength DC 15 to break, 20 hp).
+* Bone Scepter set with a Rosette of Carnelian (320 gp); +2 Imposter's Armor (av 46, 1800 gp) Drakescale Armor (av 7), +2 Magic Totem (phb2 208, 1800 gp), Arcane Ritual Book (Leomund's Secret Chest (phb 307, 360 gp), Thief's Lament (dp 158, 360 gp)) (total 720 gp), Smokestick (av 30, 150 gp); hoard total 4790 gp.
 }}
 #### Exits
 | Direction | Description | To |
@@ -1629,8 +1629,8 @@ Stone barricades (provides cover, Strength DC 30 to break), A large kiln and coa
 ### Room 110
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (Perception DC 20 to find) Locked Iron Chest (Thievery DC 15 to unlock, Strength DC 30 to break, 60 hp)
-* 2520 sp; 2 x Carved Rhodochrosite (177 gp each), Small Rose Quartz (180 gp each); Bone Chalice set with Chrysoberyl (290 gp), Brass Orb inlaid with a Filigree of Copper (410 gp), Malachite Puzzle Box inlaid with Silver (320 gp), Rosewood Bowl inlaid with a Meandros of Silver (360 gp); +2 Magic Staff (phb 241, 1800 gp), +2 Magic Totem (phb2 208, 1800 gp), 5 x Augmenting Whetstone (av 190, 75 gp), 3 x Martial Practice (Long-Distance Runner (mp2 150, 150 gp)); hoard total 6591 gp
+* Hidden (Perception DC 20 to find) Locked Iron Chest (Thievery DC 15 to unlock, Strength DC 30 to break, 60 hp).
+* 2520 sp; 2 x Carved Rhodochrosite (177 gp each), Small Rose Quartz (180 gp each); Bone Chalice set with Chrysoberyl (290 gp), Brass Orb inlaid with a Filigree of Copper (410 gp), Malachite Puzzle Box inlaid with Silver (320 gp), Rosewood Bowl inlaid with a Meandros of Silver (360 gp); +2 Magic Staff (phb 241, 1800 gp), +2 Magic Totem (phb2 208, 1800 gp), 5 x Augmenting Whetstone (av 190, 75 gp), 3 x Martial Practice (Long-Distance Runner (mp2 150, 150 gp)); hoard total 6591 gp.
 }}
 {{footnote LOCATIONS}}
 \page
@@ -1686,7 +1686,7 @@ A faded and torn tapestry hangs from the west wall, and a ruined chain shirt lie
 ### Room 115
 {{trap
 #### Trap!
-* 4 x Spinning Floortile (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp)
+* 4 x Spinning Floortile (Perception DC 12 to find, Thievery DC 12 to disable, Single-shot, Melee 1, Attack +9 vs. Reflex, the target is knocked prone, 63 xp).
 }}
 {{descriptive
 Intermittent obstructions (provides cover), Someone has scrawled "Cyna died here" in blood on the north wall.
@@ -1751,7 +1751,7 @@ This room is occupied by **6 x Mad Wraith (mm 266, 250 xp)**
 ### Room 119
 {{trap
 #### Trap!
-* 7 x Ice Bolter (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 3d8+4 cold, 63 xp)
+* 7 x Ice Bolter (Perception DC 12 to find, Thievery DC 17 to disable, Single-shot, Target 1 creature within 10 squares, Attack +11 vs. AC, Damage 3d8+4 cold, 63 xp).
 }}
 {{descriptive
 Primordial altar (thunder atacks deal 1d6 extra damage), Spirals of yellow stones cover the floor.

--- a/tests/outputs/5e.txt
+++ b/tests/outputs/5e.txt
@@ -809,7 +809,7 @@ Here you will find useful reference tables for things encountered in the dungeon
 ## Bugbear
 *Medium Humanoid, Chaotic Evil*
 ___
-**Armor Class** :: 16 armor
+**Armor Class** :: 16 (hide armor, shield)
 **Hit Points** :: 27 (5d8+5)
 **Speed** :: 30 ft.
 ___
@@ -834,7 +834,7 @@ ___
 ## Goblin
 *Small Humanoid, Neutral Evil*
 ___
-**Armor Class** :: 15 armor
+**Armor Class** :: 15 (leather armor, shield)
 **Hit Points** :: 7 (2d6)
 **Speed** :: 30 ft.
 ___
@@ -857,7 +857,7 @@ ___
 ## Hobgoblin
 *Medium Humanoid, Lawful Evil*
 ___
-**Armor Class** :: 18 armor
+**Armor Class** :: 18 (chain mail, shield)
 **Hit Points** :: 11 (2d8+2)
 **Speed** :: 30 ft.
 ___
@@ -882,7 +882,7 @@ ___
 ## Mimic
 *Medium Monstrosity, Neutral*
 ___
-**Armor Class** :: 12 natural
+**Armor Class** :: 12 (natural)
 **Hit Points** :: 58 (9d8+18)
 **Speed** :: 15 ft.
 ___
@@ -912,7 +912,7 @@ ___
 ## Ogre zombie
 *Large Undead, Neutral Evil*
 ___
-**Armor Class** :: 8 dex
+**Armor Class** :: 8 
 **Hit Points** :: 85 (9d10+36)
 **Speed** :: 30 ft.
 ___
@@ -935,7 +935,7 @@ ___
 ## Orc
 *Medium Humanoid, Chaotic Evil*
 ___
-**Armor Class** :: 13 armor
+**Armor Class** :: 13 (hide armor)
 **Hit Points** :: 15 (2d8+6)
 **Speed** :: 30 ft.
 ___
@@ -961,7 +961,7 @@ ___
 ## Silver dragon wyrmling
 *Medium Dragon, Lawful Good*
 ___
-**Armor Class** :: 17 natural
+**Armor Class** :: 17 (natural)
 **Hit Points** :: 45 (6d8+18)
 **Speed** :: 30 ft., Fly 60 ft.
 ___
@@ -987,7 +987,7 @@ Paralyzing Breath. The dragon exhales paralyzing gas in a 15-foot cone. Each cre
 ## Worg
 *Large Monstrosity, Neutral Evil*
 ___
-**Armor Class** :: 13 natural
+**Armor Class** :: 13 (natural)
 **Hit Points** :: 26 (4d10+4)
 **Speed** :: 50 ft.
 ___
@@ -1008,7 +1008,7 @@ ___
 ## Zombie
 *Medium Undead, Neutral Evil*
 ___
-**Armor Class** :: 8 dex
+**Armor Class** :: 8 
 **Hit Points** :: 22 (3d8+9)
 **Speed** :: 20 ft.
 ___

--- a/tests/outputs/5e.txt
+++ b/tests/outputs/5e.txt
@@ -115,7 +115,7 @@ This room is occupied by **Mimic (cr 2, mm 220); deadly, 450 xp**
 ### Room 5
 {{trap
 #### Trap!
-* Thunderstone Mine: DC 15 to find, DC 15 to disable;    affects all targets within 20 ft., DC 15 save or take 2d10 thunder damage    and become deafened for 1d4 rounds
+* Thunderstone Mine: DC 15 to find, DC 15 to disable;    affects all targets within 20 ft., DC 15 save or take 2d10 thunder damage    and become deafened for 1d4 rounds.
 }}
 {{descriptive
 A well lies in the north-west corner of the room, and a shattered hammer lies in the west side of the room.
@@ -138,16 +138,16 @@ A well lies in the north-west corner of the room, and a shattered hammer lies in
 ### Room 7
 {{trap
 #### Trap!
-* Falling Block: DC 15 to find, DC 15 to disable;    affects all targets within a 10 ft. square area, DC 12 save or take 2d10 damage
+* Falling Block: DC 15 to find, DC 15 to disable;    affects all targets within a 10 ft. square area, DC 12 save or take 2d10 damage.
 }}
 {{footnote LOCATIONS}}
 \page
 {{pageNumber,auto}}
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (DC 25 to find) Trapped and Unlocked Simple Wooden Chest (10 hp)
-* Poisoned Arrow Trap: DC 15 to find, DC 10 to disable;     +5 to hit against one target, 1d10 piercing/poison damage
-* 2100 cp, 1100 sp, 100 gp, a cloth sash threaded with silver (25 gp), a copper tankard etched with arcane runes (25 gp), a linen choker trimmed with squirrel fur (25 gp), a pewter crown inlaid with a meandros of silver (25 gp), an earthenware plate painted with floral imagery (25 gp)
+* Hidden (DC 25 to find) Trapped and Unlocked Simple Wooden Chest (10 hp).
+* Poisoned Arrow Trap: DC 15 to find, DC 10 to disable;     +5 to hit against one target, 1d10 piercing/poison damage.
+* 2100 cp, 1100 sp, 100 gp, a cloth sash threaded with silver (25 gp), a copper tankard etched with arcane runes (25 gp), a linen choker trimmed with squirrel fur (25 gp), a pewter crown inlaid with a meandros of silver (25 gp), an earthenware plate painted with floral imagery (25 gp).
 }}
 {{descriptive
 Someone has scrawled "We've run out of swords" on the east wall, and the walls are covered with scorch marks.
@@ -219,12 +219,12 @@ A chute descends from the room into a magical cyst below, and a warped spear lie
 ### Room 13
 {{trap
 #### Trap!
-* Idol of Evil: DC 20 to find, DC 15 to disable;    affects good creatures which touch the idol, DC 15 save or take 2d10 damage
+* Idol of Evil: DC 20 to find, DC 15 to disable;    affects good creatures which touch the idol, DC 15 save or take 2d10 damage.
 }}
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (DC 25 to find) Unlocked Simple Wooden Chest (10 hp)
-* 2200 cp, 900 sp, 60 gp, blue quartz (10 gp), hematite (10 gp), 2 x malachite (10 gp), 2 x moss agate (10 gp), tiger eye (10 gp), turquoise (10 gp), Spell Scroll (Nondetection) (uncommon, dmg 200), 2 x Potion of Greater Healing (uncommon, dmg 187), Potion of Water Breathing (uncommon, dmg 188)
+* Hidden (DC 25 to find) Unlocked Simple Wooden Chest (10 hp).
+* 2200 cp, 900 sp, 60 gp, blue quartz (10 gp), hematite (10 gp), 2 x malachite (10 gp), 2 x moss agate (10 gp), tiger eye (10 gp), turquoise (10 gp), Spell Scroll (Nondetection) (uncommon, dmg 200), 2 x Potion of Greater Healing (uncommon, dmg 187), Potion of Water Breathing (uncommon, dmg 188).
 }}
 {{descriptive
 A tile mosaic of a legendary battle covers the floor, and a ruined gauntlet lies in the center of the room.
@@ -331,12 +331,12 @@ This room is occupied by **Mimic (cr 2, mm 220); deadly, 450 xp**
 ### Room 22
 {{trap
 #### Trap!
-* Poison Gas Trap: DC 10 to find, DC 10 to disable;    affects all targets within a 10 ft. square area, DC 12 save or take 2d10 poison damage
+* Poison Gas Trap: DC 10 to find, DC 10 to disable;    affects all targets within a 10 ft. square area, DC 12 save or take 2d10 poison damage.
 }}
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (DC 15 to find) Unlocked Good Wooden Chest (15 hp)
-* 1700 cp, 700 sp, 110 gp, a cloth cloak threaded with dyed silk (25 gp), a cloth robe threaded with copper (25 gp), a cloth robe threaded with dyed silk (25 gp), a petrified frog engraved with a labyrinth (25 gp), a pewter crown set with onyx and sardonyx (25 gp), an earthenware tureen painted with pastoral imagery (25 gp)
+* Hidden (DC 15 to find) Unlocked Good Wooden Chest (15 hp).
+* 1700 cp, 700 sp, 110 gp, a cloth cloak threaded with dyed silk (25 gp), a cloth robe threaded with copper (25 gp), a cloth robe threaded with dyed silk (25 gp), a petrified frog engraved with a labyrinth (25 gp), a pewter crown set with onyx and sardonyx (25 gp), an earthenware tureen painted with pastoral imagery (25 gp).
 }}
 #### Exits
 | Direction | Description | To |
@@ -416,8 +416,8 @@ This room is occupied by **Ogre Zombie (cr 2, mm 316) and 1 x Zombie (cr 1/4, mm
 ### Room 29
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (DC 20 to find) Locked Iron Chest (DC 15 to unlock, DC 30 to break; 60 hp)
-* 1500 cp, 1100 sp, 90 gp, bloodstone (50 gp), citrine (50 gp), 2 x onyx (50 gp), sardonyx (50 gp)
+* Hidden (DC 20 to find) Locked Iron Chest (DC 15 to unlock, DC 30 to break; 60 hp).
+* 1500 cp, 1100 sp, 90 gp, bloodstone (50 gp), citrine (50 gp), 2 x onyx (50 gp), sardonyx (50 gp).
 }}
 {{descriptive
 The floor is covered in square tiles, alternating white and black, and someone has scrawled "The Hounds of Umfeld looted this place" on the west wall.
@@ -509,8 +509,8 @@ This room is occupied by **Goblin Boss (cr 1, mm 166) and 1 x Goblin (cr 1/4, mm
 ### Room 36
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (DC 25 to find) Locked Good Wooden Chest (DC 20 to unlock, DC 20 to break; 15 hp)
-* 2000 cp, 1300 sp, 60 gp, banded agate (10 gp), hematite (10 gp), moss agate (10 gp), Heward's Handy Haversack (rare, dmg 174), Potion of Clairvoyance (rare, dmg 187)
+* Hidden (DC 25 to find) Locked Good Wooden Chest (DC 20 to unlock, DC 20 to break; 15 hp).
+* 2000 cp, 1300 sp, 60 gp, banded agate (10 gp), hematite (10 gp), moss agate (10 gp), Heward's Handy Haversack (rare, dmg 174), Potion of Clairvoyance (rare, dmg 187).
 }}
 This room is occupied by **Orc (cr 1/2, mm 246) and 1 x Half-ogre (cr 1, mm 238); deadly, 300 xp**
 {{treasure
@@ -565,8 +565,8 @@ This room is occupied by **Goblin Boss (cr 1, mm 166) and 1 x Goblin (cr 1/4, mm
 ### Room 40
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (DC 20 to find) Locked Simple Wooden Chest (DC 15 to unlock, DC 15 to break; 10 hp)
-* 1700 cp, 1400 sp, 70 gp
+* Hidden (DC 20 to find) Locked Simple Wooden Chest (DC 15 to unlock, DC 15 to break; 10 hp).
+* 1700 cp, 1400 sp, 70 gp.
 }}
 {{descriptive
 Someone has scrawled "right, right, straight, right" on the north wall, and a briny odor fills the east side of the room.
@@ -712,8 +712,8 @@ This room is occupied by **Silver Dragon Wyrmling (cr 2, mm 118); deadly, 450 xp
 ### Room 51
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden (DC 15 to find) Locked Iron Chest (DC 15 to unlock, DC 30 to break; 60 hp)
-* 1100 cp, 1100 sp, 60 gp, azurite (10 gp), eye agate (10 gp), hematite (10 gp), lapis lazuli (10 gp), moss agate (10 gp), turquoise (10 gp), 2 x Potion of Animal Friendship (uncommon, dmg 187)
+* Hidden (DC 15 to find) Locked Iron Chest (DC 15 to unlock, DC 30 to break; 60 hp).
+* 1100 cp, 1100 sp, 60 gp, azurite (10 gp), eye agate (10 gp), hematite (10 gp), lapis lazuli (10 gp), moss agate (10 gp), turquoise (10 gp), 2 x Potion of Animal Friendship (uncommon, dmg 187).
 }}
 {{descriptive
 Someone has scrawled "The walls listen" on the east wall, and a shallow pool of oil lies in the south side of the room.
@@ -743,7 +743,7 @@ This room is occupied by **Orog (cr 2, mm 247); deadly, 450 xp**
 ### Room 53
 {{trap
 #### Trap!
-* Chain Flail: DC 10 to find, DC 10 to disable;    initiative +4, 1 attack per round, +7 to hit against all targets within 5 ft., 2d10 bludgeoning damage
+* Chain Flail: DC 10 to find, DC 10 to disable;    initiative +4, 1 attack per round, +7 to hit against all targets within 5 ft., 2d10 bludgeoning damage.
 }}
 #### Exits
 | Direction | Description | To |
@@ -875,6 +875,9 @@ ___
 :
 ***Longbow.*** Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.
 }}
+{{footnote STAT BLOCKS}}
+\page
+{{pageNumber,auto}}
 {{monster,frame
 ## Mimic
 *Medium Monstrosity, Neutral*
@@ -905,9 +908,6 @@ ___
 :
 ***Bite.*** Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) acid damage.
 }}
-{{footnote STAT BLOCKS}}
-\page
-{{pageNumber,auto}}
 {{monster,frame
 ## Ogre zombie
 *Large Undead, Neutral Evil*
@@ -954,6 +954,9 @@ ___
 :
 ***Javelin.*** Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 6 (1d6 + 3) piercing damage.
 }}
+{{footnote STAT BLOCKS}}
+\page
+{{pageNumber,auto}}
 {{monster,frame
 ## Silver dragon wyrmling
 *Medium Dragon, Lawful Good*
@@ -1001,9 +1004,6 @@ ___
 ### Actions
 ***Bite.*** Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone.
 }}
-{{footnote STAT BLOCKS}}
-\page
-{{pageNumber,auto}}
 {{monster,frame
 ## Zombie
 *Medium Undead, Neutral Evil*

--- a/tests/outputs/adnd.txt
+++ b/tests/outputs/adnd.txt
@@ -125,7 +125,7 @@ None
 ### Room 7
 {{trap
 #### Trap!
-* Lightning Trap (4d6 damage)
+* Lightning Trap (4d6 damage).
 }}
 {{descriptive
 A ruined siege weapon sits in the south-west corner of the room, and someone has scrawled "The thief will betray you" on the south wall.
@@ -141,10 +141,10 @@ A ruined siege weapon sits in the south-west corner of the room, and someone has
 {{descriptive
 Spirals of white stones cover the floor, and the ceiling is covered with cobwebs.
 }}
-This room is occupied by **4 x Troglodyte**
 {{footnote LOCATIONS}}
 \page
 {{pageNumber,auto}}
+This room is occupied by **4 x Troglodyte**
 {{treasure
 #### Treasure
 None
@@ -453,7 +453,7 @@ Someone has scrawled "The Staff of Omens shall be lost when blades pierce the sk
 ### Room 33
 {{trap
 #### Trap!
-* Poison Dart Trap (1d4 damage plus poison; onset immediate, save or 40 damage)
+* Poison Dart Trap (1d4 damage plus poison; onset immediate, save or 40 damage).
 }}
 {{descriptive
 A wooden ladder rests against the east wall, and someone has scrawled "The Black Hounds looted this place" on the east wall.
@@ -522,7 +522,7 @@ None
 ### Room 38
 {{trap
 #### Trap!
-* Spiked Pit Trap (40', 5d6 damage)
+* Spiked Pit Trap (40', 5d6 damage).
 }}
 {{descriptive
 A magical idol of a god of thieves in the north side of the room heals all wounds of whomever sacrifices a magical item upon it (but only once), and an iron chandelier hangs from the ceiling in the north-west corner of the room.
@@ -685,7 +685,7 @@ Numerous pillars line the north wall, and someone has scrawled "Explosive runes"
 ### Room 50
 {{trap
 #### Trap!
-* Sleep Gas Trap
+* Sleep Gas Trap.
 }}
 {{descriptive
 The room has a high domed ceiling, and a set of demonic war masks hangs on the north wall.
@@ -963,7 +963,7 @@ The floor is covered in perfect hexagonal tiles, and someone has scrawled "Stay 
 ### Room 72
 {{trap
 #### Trap!
-* Scythe Trap (4d6 damage)
+* Scythe Trap (4d6 damage).
 }}
 {{descriptive
 The scent of smoke fills the east side of the room, and several pieces of rotten bread are scattered throughout the room.
@@ -1147,7 +1147,7 @@ A group of draconic faces have been carved into the north wall, and a dulled dag
 ### Room 87
 {{trap
 #### Trap!
-* Falling Ceiling Trap (save or die)
+* Falling Ceiling Trap (save or die).
 }}
 {{descriptive
 A magical mirror on the east wall answers questions with insults, and someone has scrawled "Explosive runes" on the south wall.
@@ -1216,7 +1216,7 @@ A stone dais sits in the south-west corner of the room, and a cube of solid ston
 ### Room 92
 {{trap
 #### Trap!
-* Falling Block Trap (4d6 damage)
+* Falling Block Trap (4d6 damage).
 }}
 {{descriptive
 Several headless statues are scattered throughout the room, and someone has scrawled "In the Empire of Tomes, when the Elven Blade is lost, the Tower of Storms shall be destroyed" on the west wall.
@@ -1277,8 +1277,8 @@ This room is occupied by **5 x Large Spider**
 ### Room 97
 {{hidden-treasure
 #### Hidden Treasure!
-* Invisible Unlocked Iron Chest
-* 4000 sp
+* Invisible Unlocked Iron Chest.
+* 4000 sp.
 }}
 {{descriptive
 Someone has scrawled a large X on the east wall, and a shattered sword lies in the center of the room.
@@ -1294,7 +1294,7 @@ Someone has scrawled a large X on the east wall, and a shattered sword lies in t
 ### Room 98
 {{trap
 #### Trap!
-* Sleep Gas Trap
+* Sleep Gas Trap.
 }}
 {{descriptive
 A balcony hangs from the west wall, and a tile labyrinth covers the floor.
@@ -1650,9 +1650,9 @@ A chute descends from the room into the next dungeon level down, and someone has
 ### Room 127
 {{hidden-treasure
 #### Hidden Treasure!
-* Trapped and Locked Iron Chest (common lock)
-* Acid Trap (4d6 damage)
-* 4000 cp
+* Trapped and Locked Iron Chest (common lock).
+* Acid Trap (4d6 damage).
+* 4000 cp.
 }}
 {{descriptive
 A set of demonic war masks hangs on the east wall, and someone has scrawled "Beneath the altar" on the south wall.
@@ -1836,7 +1836,7 @@ A circle of tall stones stands in the north-east corner of the room, and the flo
 ### Room 142
 {{trap
 #### Trap!
-* Sleep Gas Trap
+* Sleep Gas Trap.
 }}
 {{descriptive
 Several iron cages are scattered throughout the room, and a pile of barrel staves lies in the south side of the room.
@@ -1922,7 +1922,7 @@ The floor is covered in square tiles, alternating white and black, and a cube of
 ### Room 149
 {{trap
 #### Trap!
-* Net Trap
+* Net Trap.
 }}
 {{descriptive
 Someone has scrawled "Trespassers will be flayed alive" in blood on the west wall, and the sound of horns can be heard in the north side of the room.
@@ -2014,7 +2014,7 @@ A group of draconic faces have been carved into the south wall, and a swarm of c
 ### Room 157
 {{trap
 #### Trap!
-* Sleep Gas Trap
+* Sleep Gas Trap.
 }}
 {{descriptive
 Someone has scrawled a basic map of the dungeon on the north wall, and a rusted chain lies in the north side of the room.
@@ -2060,7 +2060,7 @@ None
 ### Room 160
 {{trap
 #### Trap!
-* Lightning Trap (4d6 damage)
+* Lightning Trap (4d6 damage).
 }}
 {{descriptive
 A rotting carpet and simple cabinet sit in the west side of the room, and a pile of bent copper coins lies in the east side of the room.
@@ -2148,7 +2148,7 @@ A cube of solid stone stands in the west side of the room, and a clicking noise 
 ### Room 167
 {{trap
 #### Trap!
-* Falling Ceiling Trap (save or die)
+* Falling Ceiling Trap (save or die).
 }}
 {{descriptive
 A stone dais sits in the north-west corner of the room, and a faded and torn tapestry hangs from the west wall.
@@ -2399,7 +2399,7 @@ None
 ### Room 187
 {{trap
 #### Trap!
-* Net Trap
+* Net Trap.
 }}
 {{descriptive
 The floor is covered in square tiles, alternating white and black, and lit candles are scattered across the floor.
@@ -2415,7 +2415,7 @@ The floor is covered in square tiles, alternating white and black, and lit candl
 ### Room 188
 {{trap
 #### Trap!
-* Falling Block Trap (4d6 damage)
+* Falling Block Trap (4d6 damage).
 }}
 {{descriptive
 A carved stone statue stands in the center of the room, and the south and east walls are covered with slime.

--- a/tests/outputs/fantasy.txt
+++ b/tests/outputs/fantasy.txt
@@ -56,8 +56,8 @@ There are also roaming groups with specific goals, this will help you place them
 ### Room 1
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden Locked Good Wooden Chest (good lock)
-* 500 sp; Full Plate (1500 gp); hoard total 1550 gp
+* Hidden Locked Good Wooden Chest (good lock).
+* 500 sp; Full Plate (1500 gp); hoard total 1550 gp.
 }}
 {{descriptive
 A magical pool in the north-west corner of the room summons a water elemental to serve whomever drinks from it (but only once), and a tile mosaic of geometric patterns covers the floor.
@@ -128,13 +128,13 @@ None
 ### Room 6
 {{trap
 #### Trap!
-* Ceiling Pendulum
+* Ceiling Pendulum.
 }}
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden Trapped and Locked Simple Wooden Chest (superior lock)
-* Poison Needle Trap
-* 2000 cp; hoard total 20 gp
+* Hidden Trapped and Locked Simple Wooden Chest (superior lock).
+* Poison Needle Trap.
+* 2000 cp; hoard total 20 gp.
 }}
 {{descriptive
 A well lies in the north-west corner of the room, and a corroded iron key hangs from a hook on the south and west walls.
@@ -162,6 +162,9 @@ This room is occupied by **1 x Ghoul**
 #### Treasure
 1000 cp; Jet (110 gp); hoard total 120 gp
 }}
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
@@ -170,9 +173,6 @@ This room is occupied by **1 x Ghoul**
 | South | Stuck Good Wooden Door  | 25 |
 | West | Secret Unlocked Simple Wooden Door ***Secret:*** The door is concealed behind a tapestry of a goddess of wealth | 7 |
 :
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 ### Room 9
 #### Exits
 | Direction | Description | To |
@@ -239,7 +239,7 @@ None
 ### Room 14
 {{trap
 #### Trap!
-* Scything Blade Trap
+* Scything Blade Trap.
 }}
 #### Exits
 | Direction | Description | To |
@@ -262,6 +262,9 @@ A magical altar of a goddess of death in the south-east corner of the room cause
 {{descriptive
 Skeletons hang from chains and manacles against the east and west walls, and a briny odor fills the west side of the room.
 }}
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
@@ -272,9 +275,6 @@ Skeletons hang from chains and manacles against the east and west walls, and a b
 {{descriptive
 A stair ascends to a wooden platform in the south side of the room, and several pieces of rotten leather are scattered throughout the room.
 }}
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
@@ -342,7 +342,7 @@ None
 ### Room 24
 {{trap
 #### Trap!
-* Bricks from Ceiling
+* Bricks from Ceiling.
 }}
 {{descriptive
 A magical statue in the north-west corner of the room speaks riddles and cryptic prophecies, and a mural of a goddess of plants covers the ceiling.
@@ -362,7 +362,7 @@ None
 ### Room 25
 {{trap
 #### Trap!
-* Bricks from Ceiling
+* Bricks from Ceiling.
 }}
 {{descriptive
 An acrid odor fills the north-east corner of the room, and a bent dagger lies in the south-west corner of the room.
@@ -374,6 +374,9 @@ An acrid odor fills the north-east corner of the room, and a bent dagger lies in
 | South | Unlocked Simple Wooden Door  | n/a |
 | South | Stuck Simple Wooden Door  | n/a |
 :
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 ### Room 26
 {{descriptive
 The floor is covered in perfect hexagonal tiles, and a spinning wheel and several crates sit in the east side of the room.
@@ -386,9 +389,6 @@ The floor is covered in perfect hexagonal tiles, and a spinning wheel and severa
 | North | Secret Stuck Strong Wooden Door ***Secret:*** The door is concealed behind a statue of a troll archer, and opened by pulling an arrow in its quiver | n/a |
 | West | Iron Portcullis  | 53 |
 :
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 ### Room 27
 {{descriptive
 A forge and anvil sit in the west side of the room, and a torn backpack lies in the west side of the room.
@@ -474,6 +474,9 @@ A magical statue in the north-west corner of the room speaks riddles and cryptic
 | East | Trapped and Stuck Good Wooden Door  ***Trap:*** Acid Arrow Trap | 12 |
 | West | Trapped Wooden Portcullis  | 11 |
 :
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 ### Room 34
 #### Exits
 | Direction | Description | To |
@@ -486,9 +489,6 @@ A magical statue in the north-west corner of the room speaks riddles and cryptic
 A stone stair ascends towards the west wall, and spirals of white stones cover the floor.
 }}
 This room is occupied by **1 x Medium Monstrous Spider**
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 {{treasure
 #### Treasure
 500 sp; Aquamarine (500 gp); Chain Shirt (100 gp); hoard total 650 gp
@@ -573,6 +573,9 @@ Quarterstaff (0 gp); hoard total
 {{descriptive
 A narrow shaft falls into the room from above, and several headless statues are scattered throughout the room.
 }}
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
@@ -583,9 +586,6 @@ A narrow shaft falls into the room from above, and several headless statues are 
 {{descriptive
 A narrow pit covered by iron bars lies in the west side of the room, and the scent of urine fills the north-east corner of the room.
 }}
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
@@ -685,13 +685,13 @@ This room is occupied by **1 x 1st Level Warrior Drow Elf**
 | North | Wooden Portcullis  | 52 |
 | West | Unlocked Strong Wooden Door  | n/a |
 :
+{{footnote LOCATIONS}}
+\page
+{{pageNumber,auto}}
 ### Room 52
 {{descriptive
 A sloped pit lined with iron spikes lies in the south side of the room, and a toppled statue lies in the south side of the room.
 }}
-{{footnote LOCATIONS}}
-\page
-{{pageNumber,auto}}
 #### Exits
 | Direction | Description | To |
 |:--|:--|:--|
@@ -715,13 +715,13 @@ A set of demonic war masks hangs on the east wall, and several pieces of rotten 
 ### Room 54
 {{trap
 #### Trap!
-* Javelin Trap
+* Javelin Trap.
 }}
 {{hidden-treasure
 #### Hidden Treasure!
-* Hidden Trapped and Locked Simple Wooden Chest (common lock)
-* Fusillade of Darts
-* 120 gp; hoard total 120 gp
+* Hidden Trapped and Locked Simple Wooden Chest (common lock).
+* Fusillade of Darts.
+* 120 gp; hoard total 120 gp.
 }}
 #### Exits
 | Direction | Description | To |

--- a/tests/tests_e2e.py
+++ b/tests/tests_e2e.py
@@ -14,25 +14,25 @@ class E2E(TestCase):
         os.system(f"{command_line.format(test_data_dir, test_output_dir, 'fantasy')}")
         with open(f"{test_output_dir}fantasy.txt", "r", encoding="utf-8") as fantasy:
             check_value = len(fantasy.read())
-            assert check_value == 26330, f"Should be 26330 but is {check_value}"
+            assert check_value == 26343, f"Should be 26343 but is {check_value}"
 
 
     def test_adnd(self):
         os.system(f"{command_line.format(test_data_dir, test_output_dir, 'adnd')}")
         with open(f"{test_output_dir}adnd.txt", "r", encoding="utf-8") as adnd:
             check_value = len(adnd.read())
-            assert check_value == 82540, f"Should be 82540 but is {check_value}"
+            assert check_value == 82560, f"Should be 82560 but is {check_value}"
 
 
     def test_4e(self):
         os.system(f"{command_line.format(test_data_dir, test_output_dir, '4e')}")
         with open(f"{test_output_dir}4e.txt", "r", encoding="utf-8") as fourth:
             check_value = len(fourth.read())
-            assert check_value == 89067, f"Should be 89067 but is {check_value}"
+            assert check_value == 89128, f"Should be 89128 but is {check_value}"
 
 
     def test_5e(self):
         os.system(f"{command_line.format(test_data_dir, test_output_dir, '5e')}")
         with open(f"{test_output_dir}5e.txt", "r", encoding="utf-8") as fifth:
             check_value = len(fifth.read())
-            assert check_value == 41867, f"Should be 41867 but is {check_value}"
+            assert check_value == 41887, f"Should be 41887 but is {check_value}"

--- a/tests/tests_e2e.py
+++ b/tests/tests_e2e.py
@@ -35,4 +35,4 @@ class E2E(TestCase):
         os.system(f"{command_line.format(test_data_dir, test_output_dir, '5e')}")
         with open(f"{test_output_dir}5e.txt", "r", encoding="utf-8") as fifth:
             check_value = len(fifth.read())
-            assert check_value == 41887, f"Should be 41887 but is {check_value}"
+            assert check_value == 41942, f"Should be 41942 but is {check_value}"

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase, mock
 from unittest.mock import patch
-from dth.utilities import locations, statblocks, ai
+from dth.utilities import locations, statblocks, ai, summary
 
 
 # locations test data
@@ -54,6 +54,10 @@ BOTH = {"proficiencies": [
 			}
 		}
 	]}
+
+# summary test data
+xp_list = [100, 100, 100, 100, 100]
+monster_list = ["Goblin", "Adult Black Dragon", "Goblin", "Beholder", "Roper", "Goblin"]
 
 
 class Locations(TestCase):
@@ -340,3 +344,20 @@ class AI(TestCase):
         mock_send_prompt.side_effect = SystemError("error")
         with self.assertRaises(SystemError):
             ai.suggest_adventure_hooks_via_ai("foobar", "foo", "bar")
+
+
+class Summary(TestCase):
+    """ Test cases for summary helper functions """  
+    # check xp and shared xp totals
+    def test_calculate_total_and_shared_xp(self):
+        total_xp, shared_xp = summary.calculate_total_and_shared_xp(xp_list, party_size=5)
+
+        self.assertEqual(total_xp, 500)
+        self.assertEqual(shared_xp, 100)
+
+
+    # check list deduper and sorter
+    def test_dedupe_and_sort_list_via_dict(self):
+        sorted_list = summary.dedupe_and_sort_list_via_dict(monster_list)
+
+        self.assertEqual(sorted_list, ["Adult Black Dragon", "Beholder", "Goblin", "Roper"])

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -54,6 +54,36 @@ BOTH = {"proficiencies": [
 			}
 		}
 	]}
+ARMOUR = [
+		{
+			"type": "armor",
+			"value": 15,
+			"armor": [
+				{
+					"index": "leather-armor",
+					"name": "Leather Armor",
+					"url": "/api/equipment/leather-armor"
+				},
+				{
+					"index": "shield",
+					"name": "Shield",
+					"url": "/api/equipment/shield"
+				}
+			]
+		}
+	]
+NATURAL_ARMOUR = [
+		{
+			"type": "natural",
+			"value": 19
+		}
+	]
+NO_ARMOUR = [
+		{
+			"type": "dex",
+			"value": 12
+		}
+	]
 
 # summary test data
 xp_list = [100, 100, 100, 100, 100]
@@ -284,6 +314,25 @@ class Statblocks(TestCase):
         response = statblocks.convert_low_cr_to_fraction(0.5)
 
         self.assertIn(response, "1/2")
+
+
+    # check correct armour types are returned
+    def test_format_armour_types_for_armour(self):
+        response = statblocks.format_armour_type(ARMOUR)
+
+        self.assertEqual(response, "(leather armor, shield)")
+
+
+    def test_format_armour_types_for_natural_armour(self):
+        response = statblocks.format_armour_type(NATURAL_ARMOUR)
+
+        self.assertEqual(response, "(natural)")
+
+
+    def test_format_armour_types_for_no_armour(self):
+        response = statblocks.format_armour_type(NO_ARMOUR)
+
+        self.assertEqual(response, "")
 
 
 class AI(TestCase):


### PR DESCRIPTION
- [x] Split logic and parser for statblocks to enable better page break logic to be added
- [x] Added page break logic to overview
- [x] Added page break logic to summary page - monster and magic item tables
- [x] Split out logic to dedupe and sort lists from summary page to helper function file
- [x] Unit tests for summary helper functions
- [x] Added punctuation to traps and hidden treasure bullet points
- [x] Bug fixes:
  - [x] Correct armour types show on stat blocks 